### PR TITLE
Fix: /token/refresh 401

### DIFF
--- a/src/api/users.py
+++ b/src/api/users.py
@@ -36,7 +36,7 @@ async def login(
         value=refresh_token,
         httponly=True,
         secure=True,
-        samesite="lax",
+        samesite="none",
         max_age=60 * 60 * 24 * 7,  # 7 days
     )
 
@@ -49,7 +49,7 @@ async def logout(response: Response):
     Logout user by deleting refresh_token cookie.
     """
     response.delete_cookie(
-        key="refresh_token", httponly=True, secure=True, samesite="lax"
+        key="refresh_token", httponly=True, secure=True, samesite="none"
     )
     return {"message": "Logged out successfully"}
 
@@ -76,7 +76,7 @@ async def refresh(
             value=new_refresh_token,
             httponly=True,
             secure=True,
-            samesite=None,
+            samesite="none",
             max_age=60 * 60 * 24 * 7,  # 7 days
         )
 

--- a/src/api/users.py
+++ b/src/api/users.py
@@ -76,7 +76,7 @@ async def refresh(
             value=new_refresh_token,
             httponly=True,
             secure=True,
-            samesite="lax",
+            samesite=None,
             max_age=60 * 60 * 24 * 7,  # 7 days
         )
 


### PR DESCRIPTION
When SameSite=Lax, the browser won't send cookies on cross-origin POST requests. Setting SameSite=None allows the browser to include cookies in cross-origin requests.